### PR TITLE
Update roto filter syntax to match changes in the roto crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,7 +2022,7 @@ dependencies = [
 [[package]]
 name = "roto"
 version = "0.1.0"
-source = "git+https://github.com/NLnetLabs/roto.git?branch=more-route-identity-work#38ede6de44a33519e3d0fb2c211403e96f92a285"
+source = "git+https://github.com/NLnetLabs/roto.git#d60cf974cf7996ff3ad93c8bf688f792fc1c0fed"
 dependencies = [
  "arc-swap",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ layout-rs          = { version = "^0.1", optional = true }
 mqtt               = { version = "0.18.0", package = "rumqttc", default-features = false, optional = true }
 non-empty-vec      = { version = "^0.2", features = ["serde"]}
 percent-encoding   = "^2.2"
-roto               = { version = "0.1.0", git = "https://github.com/NLnetLabs/roto.git", branch = "more-route-identity-work" }
+roto               = { version = "0.1.0", git = "https://github.com/NLnetLabs/roto.git" }
 rotonda-store      = { version = "0.3.0-pre.3", git = "https://github.com/NLnetLabs/rotonda-store.git" }
 serde_with         = "^3"
 smallvec           = { version = "^1.10", features = ["const_generics", "const_new", "union"] }


### PR DESCRIPTION
This minor change fixes the four failing Roto script related tests.