### PR TITLE
Roto script compilation and error handling enhancements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "roto"
 version = "0.1.0"
-source = "git+https://github.com/NLnetLabs/roto.git?branch=compose-messages-nlri-v2#c0149d570d94871b6fc060061697ba6ff704a9ca"
+source = "git+https://github.com/NLnetLabs/roto.git?branch=compose-messages-nlri-v2#6547540ae6aa2e873189ead3f3192c2e7ac2a809"
 dependencies = [
  "arc-swap",
  "bytes",

--- a/src/common/frim.rs
+++ b/src/common/frim.rs
@@ -177,6 +177,10 @@ where
         }
     }
 
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.get(key).is_some()
+    }
+
     pub fn get(&self, key: &K) -> Option<V> {
         self.inner
             .load()

--- a/src/common/roto.rs
+++ b/src/common/roto.rs
@@ -1,30 +1,275 @@
-use std::{cell::RefCell, ops::ControlFlow, sync::Arc, time::Instant};
+use std::{
+    cell::RefCell,
+    collections::hash_map::DefaultHasher,
+    fmt::Display,
+    hash::{Hash, Hasher},
+    ops::{ControlFlow, Deref},
+    path::PathBuf,
+    sync::Arc,
+    time::Instant,
+};
 
-use arc_swap::ArcSwap;
-use log::error;
+use arc_swap::ArcSwapOption;
+use log::debug;
 use roto::{
-    compile::{Compiler, MirBlock},
+    ast::AcceptReject,
+    compile::{CompileError, Compiler, MirBlock},
     traits::RotoType,
     types::typevalue::TypeValue,
-    vm::{ExtDataSource, LinearMemory, OutputStreamQueue, VirtualMachine, VmBuilder},
+    vm::{
+        ExtDataSource, LinearMemory, OutputStreamQueue, VirtualMachine, VmBuilder, VmError,
+        VmResult,
+    },
 };
+
+use super::frim::FrimMap;
 
 pub type VM = VirtualMachine<Arc<[MirBlock]>, Arc<[ExtDataSource]>>;
 pub type ThreadLocalVM = RefCell<Option<(Instant, VM, LinearMemory)>>;
 
-#[allow(clippy::type_complexity)]
-pub fn build_vm(source_code: &str) -> Result<VM, String> {
-    let rotolo = Compiler::build(source_code)?;
-    let pack = rotolo
-        .retrieve_first_public_as_arcs()
-        .map_err(|err| format!("{}", err))?;
-    let vm = VmBuilder::new()
-        .with_mir_code(pack.mir)
-        .with_data_sources(pack.data_sources)
-        .build()
-        .map_err(|err| format!("{}", err))?;
-    Ok(vm)
+//------------ RotoError ----------------------------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub enum RotoError {
+    CompileError {
+        origin: RotoScriptOrigin,
+        err: CompileError,
+    },
+    BuildError {
+        origin: RotoScriptOrigin,
+        err: VmError,
+    },
+    ExecError {
+        origin: RotoScriptOrigin,
+        err: VmError,
+    },
+    PostExecError {
+        origin: RotoScriptOrigin,
+        err: String,
+    },
+    Unusable {
+        origin: RotoScriptOrigin,
+    },
 }
+
+impl Display for RotoError {
+    #[rustfmt::skip]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RotoError::CompileError{ origin, err } => {
+                f.write_fmt(format_args!("Compilation error for Roto script {origin}: {err}"))
+            }
+            RotoError::BuildError{ origin, err } => {
+                f.write_fmt(format_args!("VM build error for Roto script {origin}: {err}"))
+            }
+            RotoError::ExecError{ origin, err } => {
+                f.write_fmt(format_args!("VM exec error for Roto script {origin}: {err}"))
+            }
+            RotoError::PostExecError{ origin, err } => {
+                f.write_fmt(format_args!("Post execution error with Roto script {origin}: {err}"))
+            }
+            RotoError::Unusable{ origin } => {
+                f.write_fmt(format_args!("Roto script {origin} was previously determined to be unusable"))
+            }
+        }
+    }
+}
+
+//----------- RotoScripts ---------------------------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+pub enum RotoScriptOrigin {
+    Unknown,
+    Path(PathBuf),
+}
+
+impl Display for RotoScriptOrigin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RotoScriptOrigin::Unknown => f.write_str("Unknown"),
+            RotoScriptOrigin::Path(path) => f.write_fmt(format_args!("{}", path.display())),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct RotoScriptInner {
+    source_code: String,
+    origin: RotoScriptOrigin,
+    when: Instant,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RotoScript {
+    inner: Arc<ArcSwapOption<RotoScriptInner>>,
+    manager: RotoScripts,
+}
+
+impl RotoScript {
+    pub fn new<T: Into<String>>(
+        source_code: T,
+        manager: RotoScripts,
+        origin: RotoScriptOrigin,
+    ) -> Self {
+        let inner = RotoScriptInner {
+            source_code: source_code.into(),
+            origin,
+            when: Instant::now(),
+        };
+
+        let inner = if inner.source_code.is_empty() {
+            None
+        } else {
+            Some(inner)
+        };
+
+        Self {
+            inner: Arc::new(ArcSwapOption::from_pointee(inner)),
+            manager,
+        }
+    }
+
+    pub fn origin(&self) -> RotoScriptOrigin {
+        match self.inner.load().deref() {
+            Some(inner) => inner.origin.clone(),
+            None => RotoScriptOrigin::Unknown,
+        }
+    }
+
+    pub fn update(&self, source_code: String, origin: RotoScriptOrigin) {
+        let new_script = RotoScriptInner {
+            source_code,
+            origin,
+            when: Instant::now(),
+        };
+        let new_script = if new_script.source_code.is_empty() {
+            None
+        } else {
+            Some(Arc::new(new_script))
+        };
+        self.inner.store(new_script);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.load().is_none()
+    }
+
+    pub fn exec(&self, vm: &ThreadLocalVM, rx: TypeValue) -> Result<VmResult, RotoError> {
+        // Let the payload through if it is actually an output stream message as we don't filter those, we just forward them
+        // down the pipeline to a target where they can be handled, or if no roto script exists.
+        if matches!(rx, TypeValue::OutputStreamMessage(_)) || self.is_empty() {
+            return Ok(VmResult {
+                accept_reject: AcceptReject::Accept,
+                rx,
+                tx: None,
+                output_stream_queue: OutputStreamQueue::new(),
+            });
+        }
+
+        let guard = self.inner.load();
+        let script = guard.as_ref().unwrap(); // SAFETY: checked above
+
+        // Initialize the Roto script VM on first use.
+        let prev_vm = &mut vm.borrow_mut();
+        if prev_vm.is_none() {
+            let when = Instant::now();
+            let vm = self.manager.build_vm(&script.source_code, &script.origin)?;
+            let mem = LinearMemory::uninit();
+            prev_vm.replace((when, vm, mem));
+        }
+
+        // Reinitialize the Roto script VM if the Roto script has changed since it was last initialized,
+        // otherwise reset its state so that it is ready to process the given rx value.
+        let (when, vm, mem) = prev_vm.as_mut().unwrap();
+        if script.when > *when {
+            debug!("Updating roto VM");
+            *vm = self.manager.build_vm(&script.source_code, &script.origin)?;
+        } else {
+            vm.reset();
+        }
+
+        // Run the Roto script on the given rx value.
+        vm.exec(rx, None::<TypeValue>, None, mem)
+            .map_err(|err| RotoError::ExecError {
+                origin: script.origin.clone(),
+                err,
+            })
+    }
+}
+
+#[derive(Debug, Default)]
+struct RotoScriptsInner {
+    unusable_scripts: FrimMap<u64, ()>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RotoScripts {
+    inner: Arc<RotoScriptsInner>,
+}
+
+impl RotoScripts {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn build_vm(&self, roto_script: &str, origin: &RotoScriptOrigin) -> Result<VM, RotoError> {
+        if !self.known_bad(roto_script) {
+            self.build_vm_internal(roto_script, origin).or_else(|err| {
+                self.mark_script_unusable(roto_script);
+                Err(err)
+            })
+        } else {
+            Err(RotoError::Unusable {
+                origin: origin.clone(),
+            })
+        }
+    }
+
+    fn build_vm_internal(
+        &self,
+        roto_script: &str,
+        origin: &RotoScriptOrigin,
+    ) -> Result<VM, RotoError> {
+        let rotolo = Compiler::build(roto_script).map_err(|err| RotoError::CompileError {
+            origin: origin.clone(),
+            err,
+        })?;
+        let pack =
+            rotolo
+                .retrieve_first_public_as_arcs()
+                .map_err(|err| RotoError::CompileError {
+                    origin: origin.clone(),
+                    err,
+                })?;
+        VmBuilder::new()
+            .with_mir_code(pack.mir)
+            .with_data_sources(pack.data_sources)
+            .build()
+            .map_err(|err| RotoError::BuildError {
+                origin: origin.clone(),
+                err,
+            })
+    }
+
+    fn known_bad(&self, roto_script: &str) -> bool {
+        let roto_script_hash = Self::hash_script(roto_script);
+        self.inner.unusable_scripts.contains_key(&roto_script_hash)
+    }
+
+    fn mark_script_unusable(&self, roto_script: &str) {
+        let roto_script_hash = Self::hash_script(roto_script);
+        self.inner.unusable_scripts.insert(roto_script_hash, ());
+    }
+
+    fn hash_script(roto_script: &str) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        roto_script.hash(&mut hasher);
+        let roto_script_hash = hasher.finish();
+        roto_script_hash
+    }
+}
+
+//----------- Roto Filtering ------------------------------------------------------------------------------------------
 
 pub type FilterResult<E> = Result<ControlFlow<(), FilterOutput<TypeValue>>, E>;
 
@@ -47,77 +292,35 @@ where
     }
 }
 
-/// If not in test mode, filter the payload through the provided Roto script
-pub fn filter(
+pub fn roto_filter(
     vm: &ThreadLocalVM,
-    roto_source: Arc<ArcSwap<(Instant, String)>>,
+    roto_script: RotoScript,
     rx: TypeValue,
-) -> FilterResult<String> {
-    use log::debug;
-    use roto::{ast::AcceptReject, vm::VmResult};
-
+) -> FilterResult<RotoError> {
     // Let the payload through if it is actually an output stream message as we don't filter those, we just forward them
-    // down the pipeline to a target where they can be handled.
-    if matches!(rx, TypeValue::OutputStreamMessage(_)) {
+    // down the pipeline to a target where they can be handled, or if no roto script exists.
+    if matches!(rx, TypeValue::OutputStreamMessage(_)) || roto_script.is_empty() {
         return Ok(ControlFlow::Continue(FilterOutput::from(rx)));
-    }
-
-    // Let the payload through if no Roto script was supplied.
-    let roto_source_ref = roto_source.load();
-    if roto_source_ref.1.is_empty() {
-        return Ok(ControlFlow::Continue(FilterOutput::from(rx)));
-    }
-
-    // Initialize the Roto script VM on first use.
-    let prev_vm = &mut vm.borrow_mut();
-    if prev_vm.is_none() {
-        let when = Instant::now();
-        match build_vm(&roto_source_ref.1) {
-            Ok(vm) => {
-                let mem = LinearMemory::uninit();
-                prev_vm.replace((when, vm, mem));
-            }
-            Err(err) => {
-                let err = format!("Error while building Roto VM: {err}");
-                error!("{}", err);
-                return Err(err);
-            }
-        }
-    }
-
-    // Reinitialize the Roto script VM if the Roto script has changed since it was last initialized,
-    // otherwise reset its state so that it is ready to process the given rx value.
-    let (when, vm, mem) = prev_vm.as_mut().unwrap();
-    if roto_source_ref.0 > *when {
-        debug!("Updating roto VM");
-        match build_vm(&roto_source_ref.1) {
-            Ok(new_vm) => *vm = new_vm,
-            Err(err) => {
-                let err = format!("Error while re-building Roto VM: {err}");
-                error!("{}", err);
-                return Err(err);
-            }
-        }
-    } else {
-        vm.reset();
     }
 
     // Run the Roto script on the given rx value.
-    match vm.exec(rx, None::<TypeValue>, None, mem) {
-        Ok(VmResult {
+    let res = roto_script.exec(vm, rx)?;
+
+    match res {
+        VmResult {
             accept_reject: AcceptReject::Reject,
             ..
-        }) => {
+        } => {
             // The roto filter script said this BGP UPDATE message should be rejected.
             Ok(ControlFlow::Break(()))
         }
 
-        Ok(VmResult {
+        VmResult {
             accept_reject: AcceptReject::Accept,
             rx,
             tx,
             output_stream_queue,
-        }) => {
+        } => {
             // The roto filter script has given us a, possibly modified, rx_tx output value to continue with. It may be
             // the same value that it was given to check, or it may be a modified version of that value, or a
             // completely new value maybe even a different TypeValue variant.
@@ -128,29 +331,24 @@ pub fn filter(
             }))
         }
 
-        Ok(VmResult {
+        VmResult {
             accept_reject: AcceptReject::NoReturn,
             ..
-        }) => {
-            let err = "Roto filter NoReturn result is unexpected, BGP UPDATE message will be rejected".to_string();
-            error!("{}", err);
-            Err(err)
-        }
-
-        Err(err) => {
-            let err = format!("Error while executing Roto filter: {err}");
-            error!("{}", err);
-            Err(err)
-        }
+        } => Err(RotoError::PostExecError {
+            origin: roto_script.origin(),
+            err: "Roto filter NoReturn result is unexpected".to_string(),
+        }),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use roto::types::{builtin::U8, outputs::OutputStreamMessage, collections::Record, typedef::TypeDef};
+    use roto::types::{
+        builtin::U8, collections::Record, outputs::OutputStreamMessage, typedef::TypeDef,
+    };
     use smallvec::smallvec;
 
-    use crate::payload::{Filterable, Payload};
+    use crate::payload::{FilterError, Filterable, Payload};
 
     use super::*;
 
@@ -159,7 +357,7 @@ mod tests {
         let test_value: TypeValue = U8::new(0).into();
         let in_payload = Payload::new("test", test_value.clone());
         let out_payloads = in_payload
-            .filter(|payload| Ok(ControlFlow::Continue(payload.into())))
+            .filter(|payload| Result::<_, FilterError>::Ok(ControlFlow::Continue(payload.into())))
             .unwrap();
         assert_eq!(out_payloads.len(), 1);
         assert!(
@@ -171,12 +369,13 @@ mod tests {
     fn single_update_plus_output_stream_yields_both_as_bulk_update() {
         let test_value: TypeValue = U8::new(0).into();
         let in_payload = Payload::new("test", test_value.clone());
-        let test_output_stream_message = mk_roto_output_stream_payload(test_value.clone(), TypeDef::U8);
+        let test_output_stream_message =
+            mk_roto_output_stream_payload(test_value.clone(), TypeDef::U8);
         let mut output_stream_queue = OutputStreamQueue::new();
         output_stream_queue.push(test_output_stream_message.clone());
         let out_payloads = in_payload
             .filter(move |payload| {
-                Ok(ControlFlow::Continue(FilterOutput {
+                Result::<_, FilterError>::Ok(ControlFlow::Continue(FilterOutput {
                     rx: payload,
                     tx: None,
                     output_stream_queue: output_stream_queue.clone(),
@@ -201,7 +400,7 @@ mod tests {
         let payload2 = Payload::new("test2", test_value2.clone());
         let in_payload = smallvec![payload1, payload2];
         let out_payloads = in_payload
-            .filter(|payload| Ok(ControlFlow::Continue(payload.into())))
+            .filter(|payload| Result::<_, FilterError>::Ok(ControlFlow::Continue(payload.into())))
             .unwrap();
 
         assert_eq!(out_payloads.len(), 2);
@@ -220,12 +419,13 @@ mod tests {
         let payload1 = Payload::new("test1", test_value1.clone());
         let payload2 = Payload::new("test2", test_value2.clone());
         let in_payload = smallvec![payload1, payload2];
-        let test_output_stream_message = mk_roto_output_stream_payload(test_value1.clone(), TypeDef::U8);
+        let test_output_stream_message =
+            mk_roto_output_stream_payload(test_value1.clone(), TypeDef::U8);
         let mut output_stream_queue = OutputStreamQueue::new();
         output_stream_queue.push(test_output_stream_message.clone());
         let out_payloads = in_payload
             .filter(move |payload| {
-                Ok(ControlFlow::Continue(FilterOutput {
+                Result::<_, FilterError>::Ok(ControlFlow::Continue(FilterOutput {
                     rx: payload,
                     tx: None,
                     output_stream_queue: output_stream_queue.clone(),
@@ -251,14 +451,9 @@ mod tests {
     // --- Test helpers ------------------------------------------------------
 
     fn mk_roto_output_stream_payload(value: TypeValue, type_def: TypeDef) -> OutputStreamMessage {
-        let typedef = TypeDef::new_record_type(vec![
-            ("value", Box::new(type_def)),
-        ])
-        .unwrap();
+        let typedef = TypeDef::new_record_type(vec![("value", Box::new(type_def))]).unwrap();
 
-        let fields = vec![
-            ("value", value),
-        ];
+        let fields = vec![("value", value)];
 
         let record = Record::create_instance_with_sort(&typedef, fields).unwrap();
         OutputStreamMessage::from(record)

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,5 +1,6 @@
 //! Controlling the entire operation.
 
+use crate::common::roto::RotoScripts;
 use crate::comms::{DirectLink, Gate, GateAgent, GraphStatus, Link, UPDATE_QUEUE_LEN};
 use crate::config::{Config, ConfigFile, Marked};
 use crate::log::Failed;
@@ -46,6 +47,9 @@ pub struct Component {
 
     /// A reference to the HTTP resources collection.
     http_resources: http::Resources,
+
+    /// A reference to the Roto script collection.
+    roto_scripts: RotoScripts,
 }
 
 #[cfg(test)]
@@ -56,6 +60,7 @@ impl Default for Component {
             http_client: Default::default(),
             metrics: Default::default(),
             http_resources: Default::default(),
+            roto_scripts: Default::default(),
         }
     }
 }
@@ -67,12 +72,14 @@ impl Component {
         http_client: HttpClient,
         metrics: metrics::Collection,
         http_resources: http::Resources,
+        roto_scripts: RotoScripts,
     ) -> Self {
         Component {
             name: name.into(),
             http_client: Some(http_client),
             metrics: Some(metrics),
             http_resources,
+            roto_scripts,
         }
     }
 
@@ -84,6 +91,10 @@ impl Component {
     /// Returns a reference to an HTTP Client.
     pub fn http_client(&self) -> &HttpClient {
         self.http_client.as_ref().unwrap()
+    }
+
+    pub fn roto_scripts(&self) -> RotoScripts {
+        self.roto_scripts.clone()
     }
 
     /// Register a metrics source.
@@ -389,6 +400,9 @@ pub struct Manager {
     /// The HTTP resources collection maintained by this manager.
     http_resources: http::Resources,
 
+    /// A reference to the Roto script collection.
+    roto_scripts: RotoScripts,
+
     #[cfg(feature = "config-graph")]
     graph_svg_processor: Arc<dyn ProcessRequest>,
 
@@ -417,6 +431,7 @@ impl Manager {
             http_client: Default::default(),
             metrics: Default::default(),
             http_resources: Default::default(),
+            roto_scripts: Default::default(),
             #[cfg(feature = "config-graph")]
             graph_svg_processor,
             graph_svg_data,
@@ -829,6 +844,7 @@ impl Manager {
                 self.http_client.clone(),
                 self.metrics.clone(),
                 self.http_resources.clone(),
+                self.roto_scripts.clone(),
             );
 
             let target_type = std::mem::discriminant(&new_target);
@@ -888,6 +904,7 @@ impl Manager {
                 self.http_client.clone(),
                 self.metrics.clone(),
                 self.http_resources.clone(),
+                self.roto_scripts.clone(),
             );
 
             let unit_type = std::mem::discriminant(&new_unit);

--- a/src/units/rib_unit/status_reporter.rs
+++ b/src/units/rib_unit/status_reporter.rs
@@ -4,7 +4,7 @@ use std::{
     time::Instant,
 };
 
-use log::debug;
+use log::{debug, error};
 
 use crate::{
     common::status_reporter::{sr_log, AnyStatusReporter, Chainable, Named, UnitStatusReporter},
@@ -134,6 +134,10 @@ impl RibUnitStatusReporter {
         self.metrics
             .num_unique_prefixes
             .store(num_unique_prefixes, Ordering::SeqCst);
+    }
+
+    pub fn message_filtering_failure<T: Display>(&self, err: T) {
+        sr_log!(error: self, "Filtering error: {}", err);
     }
 }
 


### PR DESCRIPTION
Centralize roto script compilation, use a more structured approach to error handling, and avoid repeated failing attempts to compile the same script over and over again and each time dumping the verbose compilation error to the logs.