### PR TITLE
Refactor TCP server support

### DIFF
--- a/src/units/bgp_tcp_in/unit.rs
+++ b/src/units/bgp_tcp_in/unit.rs
@@ -33,6 +33,8 @@ use super::peer_config::{CombinedConfig, PeerConfigs};
 //
 // These traits enable us to swap out the real TCP listener for a mock when
 // testing.
+//
+// These were the same as in bmp-tcp-in but have since diverged.
 
 #[async_trait::async_trait]
 trait TcpListenerFactory<T> {


### PR DESCRIPTION
This PR when ready will reduce the duplication of code between the BMP and BGP TCP input units, and may also migrate to a version of the server code that was added to the `domain` crate in the [`serve-poc` branch](https://github.com/NLnetLabs/domain/compare/serve-poc?expand=1) which also has support for TLS.