### PR TITLE
Unclear cause when rotonda exits due to missing syslogd (resolves #45)

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -250,6 +250,7 @@ impl LogConfig {
             })
             .or_else(|_| {
                 error!("Syslog not available via TCP socket, falling back to udp://127.0.0.1:514");
+                error!("Warning: Logs may be lost if no syslog daemon is listening at udp://127.0.0.1:514 !");
                 syslog::udp(formatter, ("127.0.0.1", 0), ("127.0.0.1", 514))
             });
         match logger {


### PR DESCRIPTION
Notify the operator via logging to `stderr` when fallback to a different syslog transport than Unix domain sockets is attempted. If falling back to UDP also warn the operator that all bets are off if there is not actually a syslog daemon listening on the specified UDP address.