### PR TITLE
Add MQTT broker username/password authentication support.

### DIFF
--- a/etc/rotonda.conf
+++ b/etc/rotonda.conf
@@ -659,6 +659,10 @@
 #                            receive all events by subscribing to 'rotonda/#'
 #                            for example.
 #
+#     username               A "string" username for login to the MQTT broker.
+#
+#     password               A "string" password for login to the MQTT broker.
+#
 # --- Pipeline interaction ---------------------------------------------------
 #
 #                          +----------+

--- a/src/targets/mqtt/config.rs
+++ b/src/targets/mqtt/config.rs
@@ -112,6 +112,12 @@ pub struct Config {
     /// How many messages to buffer if publishing encounters delays
     #[serde(default = "Config::default_queue_size")]
     pub queue_size: u16,
+
+    #[serde(default)]
+    pub username: Option<String>,
+
+    #[serde(default)]
+    pub password: Option<String>,
 }
 
 impl Config {

--- a/src/targets/mqtt/target.rs
+++ b/src/targets/mqtt/target.rs
@@ -425,9 +425,13 @@ impl ConnectionFactory for MqttRunner<mqtt::AsyncClient> {
             config.destination.port,
         );
         create_opts.set_request_channel_capacity(config.queue_size.into());
-        create_opts.set_clean_session(false);
+        create_opts.set_clean_session(true);
         create_opts.set_inflight(1000);
         create_opts.set_keep_alive(Duration::from_secs(20));
+
+        if let (Some(username), Some(password)) = (&config.username, &config.password) {
+            create_opts.set_credentials(username, password);
+        }
 
         Connection::new(
             create_opts,


### PR DESCRIPTION
Tested with publicmqtt.bevywise.com.