### PR TITLE
Use GH hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   build:
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Ensure correct Rust toolchain version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ env:
 
 jobs:
   build:
-    runs-on: self-hosted
     steps:
     - uses: actions/checkout@v3
     - name: Ensure correct Rust toolchain version

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,6 @@ jobs:
   coverage:
     name: coverage
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
-    runs-on: self-hosted
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,7 @@ jobs:
   coverage:
     name: coverage
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/pkg-min.yml
+++ b/.github/workflows/pkg-min.yml
@@ -11,8 +11,6 @@ jobs:
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
 
     with:
-      runs_on: self-hosted
-
       #package_build_rules: pkg/rules/packages-to-build.yml
       package_test_scripts_path: pkg/test-scripts/test-<package>.sh
 

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -23,11 +23,6 @@ jobs:
     #  DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
 
     with:
-      # TODO: When ready to make this repository public, remove this `runs_on` when this repository is made public.
-      # Until then run on self-hosted runners at the office to avoid consuming the GitHub Actions credits that we
-      # also use for other things because private repositories use a limited budget of per-organization credits.
-      runs_on: self-hosted
-
       docker_org: nlnetlabs
       docker_repo: rotonda
       docker_build_rules: pkg/rules/docker-images-to-build.yml


### PR DESCRIPTION
As the repo was made public it is now possible to use GH hosted runners instead of self-hosted runner VMs  at the office. This repo makes that change.

While individual GH runners are less powerful and so slower on small workflows, the packaging workflow in particular should be faster with GH hosted runners as it can run many more jobs in parallel than with the limited number of self-hosted runner VMs that we were using.

This avoids a dependency on maintaining and upgrading runners ourselves and makes the workflow execution use the same common host environment as other NLnet Labs projects making it easier to adapt and scale, and less susceptible to downtime caused by issues with the office based host and/or network.