### PR TITLE
Enable pushing to Docker Hub when packaging.

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -15,13 +15,9 @@ on:
 jobs:
   full:
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
-
-    # TODO: When ready to make this repository public uncomment this `DOCKER_HUB_` secrets section and set the
-    # corresponding repository secrets to enable publishing Docker images to https://hub.docker.com/.
-    #secrets:
-    #  DOCKER_HUB_ID: ${{ secrets.DOCKER_HUB_ID }}
-    #  DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
-
+    secrets:
+      DOCKER_HUB_ID: ${{ secrets.DOCKER_HUB_ID }}
+      DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
     with:
       docker_org: nlnetlabs
       docker_repo: rotonda


### PR DESCRIPTION
Sample run: https://github.com/NLnetLabs/rotonda/actions/runs/7495543393/job/20405845747