### PR TITLE
Bugfix: use monotonic clock instead of chrono::DateTime in Payload

### DIFF
--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use log::debug;
 use rotonda_store::QueryResult;
 
@@ -253,7 +252,7 @@ pub struct Payload {
     pub rx_value: RotondaRoute, //RouteWorkshop<N>, //was: TypeValue,
     pub context: RouteContext,
     pub trace_id: Option<u8>,
-    pub received: DateTime<Utc>,
+    pub received: std::time::Instant,
 }
 
 impl PartialEq for Payload {
@@ -276,7 +275,7 @@ impl Payload {
             context,
             // bgp_msg,
             trace_id,
-            received: Utc::now(),
+            received: std::time::Instant::now(),
         }
     }
 
@@ -284,7 +283,7 @@ impl Payload {
         rx_value: RotondaRoute,
         context: RouteContext,
         trace_id: Option<u8>,
-        received: DateTime<Utc>,
+        received: std::time::Instant,
     ) -> Self {
         Self {
             rx_value,

--- a/src/units/bgp_tcp_in/router_handler.rs
+++ b/src/units/bgp_tcp_in/router_handler.rs
@@ -326,7 +326,7 @@ impl Processor {
                             );
 
                             let mut output_stream = RotoOutputStream::new();
-                            let received = Utc::now();
+                            let received = std::time::Instant::now();
 
                             let verdict = self.roto_function.as_ref().map(
                                 |roto_function|
@@ -550,7 +550,7 @@ impl Processor {
     // unit.
     async fn process_update(
         &mut self,
-        received: DateTime<Utc>,
+        received: std::time::Instant,
         bgp_msg: UpdateMessage<bytes::Bytes>,
         provenance: Provenance,
         //context: FreshRouteContext,
@@ -559,7 +559,7 @@ impl Processor {
     ) -> Result<Update, session::Error> {
         fn mk_payload(
             rr: RotondaRoute,
-            received: DateTime<Utc>,
+            received: std::time::Instant,
             //provenance: Option<Provenance>,
             //context: RouteContext,
             context: FreshRouteContext,

--- a/src/units/bmp_tcp_in/router_handler.rs
+++ b/src/units/bmp_tcp_in/router_handler.rs
@@ -212,7 +212,7 @@ impl RouterHandler {
                 }
 
                 Ok((Some(msg_buf), status, mut trace_id)) => {
-                    let received = Utc::now();
+                    let received = std::time::Instant::now();
 
                     // We want the stream reading to abort as soon as the Gate
                     // is terminated so we handle status updates to the Gate in
@@ -321,7 +321,7 @@ impl RouterHandler {
 
     async fn process_msg(
         &self,
-        received: DateTime<Utc>,
+        received: std::time::Instant,
         addr: SocketAddr,
         //source_id: SourceId,
         ingress_id: IngressId,
@@ -914,7 +914,7 @@ mod tests {
     ) -> Result<(), (Arc<String>, String)> {
         router_handler
             .process_msg(
-                Utc::now(),
+                std::time::Instant::now(),
                 "1.2.3.4:12345".parse().unwrap(),
                 0_u32.into(),
                 msg,

--- a/src/units/bmp_tcp_in/state_machine/machine.rs
+++ b/src/units/bmp_tcp_in/state_machine/machine.rs
@@ -675,7 +675,7 @@ where
     /// original unmodified `msg` or a modified or completely new message.
     pub fn route_monitoring<CB>(
         mut self,
-        received: DateTime<Utc>,
+        received: std::time::Instant,
         msg: RouteMonitoring<Bytes>,
         //route_status: NlriStatus,
         trace_id: Option<u8>,
@@ -841,7 +841,7 @@ where
     // multiple routes.
     pub fn extract_route_monitoring_routes(
         &mut self,
-        received: DateTime<Utc>,
+        received: std::time::Instant,
         pph: PerPeerHeader<Bytes>,
         bgp_msg: &UpdateMessage<Bytes>,
         //route_status: NlriStatus,
@@ -1122,7 +1122,7 @@ impl BmpState {
     #[allow(dead_code)]
     pub fn process_msg(
         self,
-        received: DateTime<Utc>,
+        received: std::time::Instant,
         bmp_msg: BmpMsg<Bytes>,
         trace_id: Option<u8>,
     ) -> ProcessingResult {

--- a/src/units/bmp_tcp_in/state_machine/states/dumping.rs
+++ b/src/units/bmp_tcp_in/state_machine/states/dumping.rs
@@ -184,7 +184,7 @@ impl BmpStateDetails<Dumping> {
     #[allow(dead_code)]
     pub fn process_msg(
         self,
-        received: DateTime<Utc>,
+        received: std::time::Instant,
         bmp_msg: BmpMsg<Bytes>,
         trace_id: Option<u8>,
     ) -> ProcessingResult {

--- a/src/units/bmp_tcp_in/state_machine/states/updating.rs
+++ b/src/units/bmp_tcp_in/state_machine/states/updating.rs
@@ -67,7 +67,7 @@ impl BmpStateDetails<Updating> {
     #[allow(dead_code)]
     pub fn process_msg(
         self,
-        received: DateTime<Utc>,
+        received: std::time::Instant,
         bmp_msg: BmpMsg<Bytes>,
         trace_id: Option<u8>,
     ) -> ProcessingResult {

--- a/src/units/rib_unit/unit.rs
+++ b/src/units/rib_unit/unit.rs
@@ -1005,7 +1005,7 @@ where
 
         //let ingress_id = payload.context.provenance().ingrespayload.rxs_id;
 
-        let pre_insert = Utc::now();
+        let pre_insert = std::time::Instant::now();
 
         // XXX this is where we need to adapt to the new store
         // this basically translates to
@@ -1038,11 +1038,9 @@ where
         //);
         match rib.insert(&payload.rx_value, route_status, provenance, ltime) {
             Ok(report) => {
-                let post_insert = Utc::now();
-                let store_op_delay =
-                    (post_insert - pre_insert).to_std().unwrap();
-                let propagation_delay =
-                    (post_insert - payload.received).to_std().unwrap();
+                let post_insert = std::time::Instant::now();
+                let store_op_delay = pre_insert.duration_since(post_insert);
+                let propagation_delay = payload.received.duration_since(post_insert);
 
                 let change = if report.prefix_new {
                     StoreInsertionEffect::RouteAdded


### PR DESCRIPTION
This PR removes the `to_std().unwrap()` from `chrono::DateTime<Utc>` in comparing the pre- and post-insert timestamps in the store. `DateTime<Utc>` is *not* monotonic and panics if the resulting to_std() is negative.

There are workarounds with `chrono` (signed_duration_from etc), but `chrono` is fundamentally broken and should not be used anyway. So this is a first shot to remove it.

This is not a lasting solution for `Payload` though: we will need to have an actual timestamp in there somehow, for metrics and API output, as well as storing time-series based data in the store.