### PR TITLE
Release 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "rotonda"
-version = "0.2.2-dev"
+version = "0.3.0"
 dependencies = [
  "allocator-api2",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ name = "print_rotonda_std_doc"
 path = "doc/bin/print_rotonda_std_doc.rs"
 
 [workspace.package]
-version = "0.2.2-dev"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.80"
 authors = ["NLnet Labs <routing-team@nlnetlabs.nl>"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,14 +6,18 @@ Released 2025-01-30.
 
 Breaking changes
 
-* In the embedded `roto` the _define_ and _apply_ blocks are gone. They
-  are both replaced by _let_ statements.
+* In the embedded `roto` the _define_ and _apply_ blocks are gone. Users can
+  now define variables and functions throughout the script.
 * Arguments to filter-maps in `roto` have changed: some of them are now
-  implicit. Look into the bundled examples in `etc/examples` for more details.
+  implicit.
+
+  See the bundled example in `etc/examples` for more details.
 
 
 New
 
+* In the `roto` language users can now assign variables and functions through
+   the use of `let` statements anywhere in a `roto` script.
 * In `roto`, in addition to the breaking changes, there now is support for
   constants and strings. This enables, amongst other things, customizable
   logging. 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,19 +1,59 @@
 # Changelog
 
-## New unreleased version
+## 0.3.0
 
-Released yyyy-mm-dd
+Released 2025-01-30
 
-Breaking Changes
+Breaking changes
+
+* The changes to the `roto` language include several improvements that break
+  backwards compatibility. Most notable, the _define_ and _apply_ blocks are
+  gone. Replacing the former, _let_ statements are introduced.
+
 
 New
 
-Bug Fixes
+* In `roto`, in addition to the syntax changes, there now is support for
+  constants and strings. This enables, amongst other things, customizable
+  logging. 
+  Several other helper methods on the various types, including ones to format
+  fields to strings, are introduced.
+* The new `file-out` target enables logging to a file in JSON or CSV format.
+  Several helpers to log specific features are available, as well as the
+  aforementioned custom logging via strings.
+* The `mrt-file-in` unit can now be configured to process multiple files in
+  sequence, and is able to process the most common message types seen in
+  'update' MRT files. Furthermore, _.bz2_ compressed archives can be processed.
+  A new API endpoint enables queueing of files.
+* Upon reestablishment of a previous BMP session, the previous session
+  information is looked up and re-used. This should reduce memory use, and
+  moreover, prevent confusing results when querying prefixes.
+* BMP messages originating from a _LocRib_ are now recognized and stored.
+
+
+Bug fixes
+
+* Several metric counters were not increased properly
+
+
+Known issues
+
+* The "more_specifics" field in a query result may include wrong prefixes
+
 
 Other changes
 
-* We no longed build binary packages for Debian 9 "Stretch" and Ubuntu 16.04
+* We no longer build binary packages for Debian 9 "Stretch" and Ubuntu 16.04
   LTS "Xenial Xerus".
+
+
+Acknowledgements
+
+We would like to very much thank the following people for their (ongoing) input
+and support in various ways: Tobias Fiebig, Ties de Kock, Lisa Bruder, Ralph
+Koning, Bruno Blanes.
+
+
 
 ## 0.2.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.0
+## 0.3.0 'Hempcrete & Hawthorn'
 
 Released 2025-01-30.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,18 +2,19 @@
 
 ## 0.3.0
 
-Released 2025-01-30
+Released 2025-01-30.
 
 Breaking changes
 
-* The changes to the `roto` language include several improvements that break
-  backwards compatibility. Most notable, the _define_ and _apply_ blocks are
-  gone. Replacing the former, _let_ statements are introduced.
+* In the embedded `roto` the _define_ and _apply_ blocks are gone. They
+  are both replaced by _let_ statements.
+* Arguments to filter-maps in `roto` have changed: some of them are now
+  implicit. Look into the bundled examples in `etc/examples` for more details.
 
 
 New
 
-* In `roto`, in addition to the syntax changes, there now is support for
+* In `roto`, in addition to the breaking changes, there now is support for
   constants and strings. This enables, amongst other things, customizable
   logging. 
   Several other helper methods on the various types, including ones to format
@@ -23,9 +24,9 @@ New
   aforementioned custom logging via strings.
 * The `mrt-file-in` unit can now be configured to process multiple files in
   sequence, and is able to process the most common message types seen in
-  'update' MRT files. Furthermore, _.bz2_ compressed archives can be processed.
+  `update` MRT files. Furthermore, _.bz2_ compressed archives can be processed.
   A new API endpoint enables queueing of files.
-* Upon reestablishment of a previous BMP session, the previous session
+* Upon re-establishment of a previous BMP session, the previous session
   information is looked up and re-used. This should reduce memory use, and
   moreover, prevent confusing results when querying prefixes.
 * BMP messages originating from a _LocRib_ are now recognized and stored.
@@ -33,12 +34,12 @@ New
 
 Bug fixes
 
-* Several metric counters were not increased properly
+* Several metric counters were not increased properly.
 
 
 Known issues
 
-* The "more_specifics" field in a query result may include wrong prefixes
+* The "more_specifics" field in a query result may include wrong prefixes.
 
 
 Other changes
@@ -57,7 +58,7 @@ Koning, Bruno Blanes.
 
 ## 0.2.1
 
-Released 2024-12-06
+Released 2024-12-06.
 
 Bug Fixes
 
@@ -83,7 +84,7 @@ Other changes
 
 ## 0.2.0 'Happy Fuzzballs'
 
-Released 2024-11-21
+Released 2024-11-21.
 
 Breaking changes
 


### PR DESCRIPTION
## 0.3.0 'Hempcrete & Hawthorn'

Released 2025-01-30.

Breaking changes

* In the embedded `roto` the _define_ and _apply_ blocks are gone. Users can now define variables and functions throughout the script.
* Arguments to filter-maps in `roto` have changed: some of them are now implicit.

  See the bundled example in `etc/examples` for more details.


New

* In the `roto` language users can now assign variables and functions through the use of `let` statements anywhere in a `roto` script.
* In `roto`, in addition to the breaking changes, there now is support for constants and strings. This enables, amongst other things, customizable logging.
  Several other helper methods on the various types, including ones to format fields to strings, are introduced.
* The new `file-out` target enables logging to a file in JSON or CSV format.
  Several helpers to log specific features are available, as well as the aforementioned custom logging via strings.
* The `mrt-file-in` unit can now be configured to process multiple files in sequence, and is able to process the most common message types seen in `update` MRT files. Furthermore, _.bz2_ compressed archives can be processed.
  A new API endpoint enables queueing of files.
* Upon re-establishment of a previous BMP session, the previous session information is looked up and re-used. This should reduce memory use, and moreover, prevent confusing results when querying prefixes.
* BMP messages originating from a _LocRib_ are now recognized and stored.


Bug fixes

* Several metric counters were not increased properly.


Known issues

* The "more_specifics" field in a query result may include wrong prefixes.


Other changes

* We no longer build binary packages for Debian 9 "Stretch" and Ubuntu 16.04
  LTS "Xenial Xerus".


Acknowledgements

We would like to very much thank the following people for their (ongoing) input and support in various ways: Tobias Fiebig, Ties de Kock, Lisa Bruder, Ralph Koning, Bruno Blanes.