### PR TITLE
Enable publication to Docker Hub.

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -13,12 +13,9 @@ on:
 jobs:
   full:
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
-
-    # TODO: When ready to make this repository public uncomment this `DOCKER_HUB_` secrets section and set the
-    # corresponding repository secrets to enable publishing Docker images to https://hub.docker.com/.
-    #secrets:
-    #  DOCKER_HUB_ID: ${{ secrets.DOCKER_HUB_ID }}
-    #  DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+    secrets:
+      DOCKER_HUB_ID: ${{ secrets.DOCKER_HUB_ID }}
+      DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
 
     with:
       docker_org: nlnetlabs


### PR DESCRIPTION
Once merged to main a run of the packaging workflow will cause publication to Docker Hub with the unstable Docker tag. A packaging workflow run against a Git tag instead of main will cause a release Docker tag to be made.