### PR TITLE
Loc-RIB and VRF fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2999,6 +2999,7 @@ dependencies = [
  "memmap2",
  "micromap",
  "non-empty-vec",
+ "paste",
  "percent-encoding",
  "pin-project-lite",
  "prometheus-parse",
@@ -3006,7 +3007,7 @@ dependencies = [
  "reqwest",
  "roto",
  "rotonda-store",
- "routecore",
+ "routecore 0.5.3-dev",
  "rpki",
  "rumqttc",
  "rumqttd",
@@ -3040,7 +3041,7 @@ dependencies = [
  "parking_lot_core",
  "rand 0.9.1",
  "roaring",
- "routecore",
+ "routecore 0.5.2",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3052,6 +3053,23 @@ name = "routecore"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dfe4daf99c74d8af82cfeab5e764d089fc47c47fcabffca35f9250f3f4a14a7"
+dependencies = [
+ "bytes",
+ "chrono",
+ "const-str",
+ "inetnum",
+ "log",
+ "octseq",
+ "paste",
+ "rayon",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "routecore"
+version = "0.5.3-dev"
+source = "git+https://github.com/NLnetlabs/routecore#8ed54091a3e44f99805d23c742488205434445ee"
 dependencies = [
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,8 @@ authors = ["NLnet Labs <routing-team@nlnetlabs.nl>"]
 #members = []
 
 [workspace.dependencies]
-routecore          = { version = "0.5.2", features = ["bgp", "bmp", "serde", "fsm", "mrt"] }
+#routecore          = { version = "0.5.2", features = ["bgp", "bmp", "serde", "fsm", "mrt"] }
+routecore          = { git = "https://github.com/NLnetlabs/routecore", features = ["bgp", "bmp", "serde", "fsm", "mrt"] }
 inetnum            = { version = "0.1.1", features = ["arbitrary", "serde"] }
 rotonda-store      = { version = "0.5.0" }
 log                = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ bzip2              = "0.5.0"
 rpki               = { version = "0.18.6", features = ["crypto", "rtr"] }
 futures-util       = "0.3.31"
 micromap = "0.0.19"
+paste = "1.0.15"
 
 [target.'cfg(unix)'.dependencies]
 syslog             = "6.1"

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,8 +10,17 @@ Breaking changes
 
 New
 
+* For BMP ingresses, the Peer type, Peer distinguisher, and VRF/Table name are
+  now tracked in the ingress register, and (if set) returned in HTTP API
+  responses.
 
 Bug fixes
+
+* The procedure to find known ingresses (e.g. when a BMP session is
+  re-established) would not take into account the Peer type/distinguisher and
+  VRF/Table name. This could cause mismatches, leading to routes being stored
+  in the wrong spot and/or incorrectly overwriting other routes.
+  Presumably, this only affected monitoring of Loc-RIBs.
 
 
 Known issues

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -202,7 +202,6 @@ impl Register {
     /// `ingress_id`, the remote address and ASN (all three must be set).
     /// Furthermore, the RIB type is compared, though that might be unset,
     /// i.e. None.
-    /// TODO ^^^ the macro needs to be adapted to support non-mandatory ones
     pub fn find_existing_peer(
         &self,
         query: &IngressInfo
@@ -213,7 +212,7 @@ impl Register {
                 {parent_ingress, remote_addr, remote_asn},
                 {rib_type, peer_type, distinguisher}
             ) {
-                    log::debug!("found existing peer, id {id}");
+                    //log::debug!("found existing peer, id {id}");
                     return Some((*id, info.clone()))
             }
         }

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -210,7 +210,7 @@ impl Register {
         for (id, info) in lock.iter() {
             if find_existing_for!(info, query,
                 {parent_ingress, remote_addr, remote_asn},
-                {rib_type, peer_type, distinguisher}
+                {rib_type, peer_type, distinguisher, vrf_name}
             ) {
                     //log::debug!("found existing peer, id {id}");
                     return Some((*id, info.clone()))

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -260,7 +260,8 @@ info_for_field!(IngressInfo{
    desc: String,
    local_asn: Asn,
    peer_type: PeerType,
-   distinguisher: [u8; 8]
+   distinguisher: [u8; 8],
+   vrf_name: String
 });
 
 #[cfg(test)]

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -5,7 +5,8 @@ use std::{collections::HashMap, path::PathBuf, sync::atomic::Ordering};
 use std::sync::RwLock;
 
 use inetnum::asn::Asn;
-use routecore::bmp::message::RibType;
+use routecore::bmp::message::{PeerType, RibType};
+use paste::paste;
 
 /// Register of ingress/sources, tracked in a serial way.
 ///
@@ -23,7 +24,7 @@ pub struct Register {
 
 pub type IngressId = u32;
 
-// Used to merge IngressInfo structs
+// Used to merge IngressInfo structs, called in info_for_field!
 macro_rules! update_field {
     ($old:ident, $new:ident, $field:ident) => {
         if $new.$field.is_some() {
@@ -31,6 +32,86 @@ macro_rules! update_field {
         }
     }
 }
+
+// Used to create the builder pattern methods, called in info_for_field!
+macro_rules! with_field {
+    ($name:ident, $type:ty) => {
+        paste! {
+            pub fn [<with_$name>](self, $name: impl Into<$type>) -> Self {
+                Self {
+                    $name: Some($name.into()), ..self }
+            }
+        }
+    }
+}
+
+// Creates the IngressInfo (== $name) struct and adds fn Register::update_info
+macro_rules! info_for_field{
+    ($name:ident { $($field:ident : $type:ty),* } ) => {
+
+        /// Information pertaining to an [`IngressId`]
+        ///
+        /// The `IngressInfo` struct is quite broad and generic in nature, featuring
+        /// fields that might not make sense in all use cases. Therefore, everything
+        /// is wrapped as an `Option`, giving the user (mostly connector/ingress
+        /// components within Rotonda) the flexibilty to fill in what makes sense in
+        /// their specific case.
+        #[derive(Clone, Debug, Default)]
+        #[serde_with::skip_serializing_none]
+        #[derive(serde::Serialize)]
+        pub struct $name {
+            $(
+                pub $field: Option<$type>,
+            )*
+
+            // pub last_active: Instant ? to enable 'reconnecting' remotes?
+        }
+
+        impl $name {
+            $(
+                with_field!($field, $type);
+            )*
+
+        }
+
+        impl Register {
+            /// Change the info related to an [`IngressId`]
+            pub fn update_info(
+                &self,
+                id: IngressId,
+                new_info: $name,
+            ) -> Option<$name> {
+                let mut lock = self.info.write().unwrap();
+
+                log::debug!("update_info for {id} with {new_info:?}");
+
+                if let Some(mut old) = lock.remove(&id) {
+
+                    $(
+                        update_field!(old, new_info, $field);
+                    )*
+                    lock.insert(id, old) // returns the replaced info
+                } else {
+                    lock.insert(id, new_info) // returns the replaced info
+                }
+            }
+
+        }
+    }
+}
+
+
+// Creates a boolean expression checking is_some() + equality for all fields
+macro_rules! find_existing_for {
+    ($info:ident, $query:ident, $($field:ident),*) => {
+        $(
+            $info.$field.is_some() &&
+            $info.$field == $query.$field &&
+        )*  true // just to fill up the last '&& _' from the repetition
+    }
+
+}
+
 
 impl Register {
     /// Create a new register
@@ -57,31 +138,6 @@ impl Register {
     /// Request a new, unique [`IngressId`]
     pub(crate) fn register(&self) -> IngressId {
         self.serial.fetch_add(1, Ordering::Relaxed)
-    }
-
-    /// Change the info related to an [`IngressId`]
-    pub(crate) fn update_info(
-        &self,
-        id: IngressId,
-        new_info: IngressInfo,
-    ) -> Option<IngressInfo> {
-        let mut lock = self.info.write().unwrap();
-
-        log::debug!("update_info for {id} with {new_info:?}");
-
-        if let Some(mut old) = lock.remove(&id) {
-            update_field!(old, new_info, unit_name);
-            update_field!(old, new_info, parent_ingress);
-            update_field!(old, new_info, remote_addr);
-            update_field!(old, new_info, remote_asn);
-            update_field!(old, new_info, rib_type);
-            update_field!(old, new_info, filename);
-            update_field!(old, new_info, name);
-            update_field!(old, new_info, desc);
-            lock.insert(id, old) // returns the replaced info
-        } else {
-            lock.insert(id, new_info) // returns the replaced info
-        }
     }
 
     /// Retrieve the information for the given [`IngressId`]
@@ -127,22 +183,18 @@ impl Register {
     /// `ingress_id`, the remote address and ASN (all three must be set).
     /// Furthermore, the RIB type is compared, though that might be unset,
     /// i.e. None.
+    /// TODO ^^^ the macro needs to be adapted to support non-mandatory ones
     pub fn find_existing_peer(
         &self,
         query: &IngressInfo
     ) -> Option<(IngressId, IngressInfo)> {
         let lock = self.info.read().unwrap();
         for (id, info) in lock.iter() {
-            if info.parent_ingress.is_some()
-                && info.remote_addr.is_some()
-                && info.remote_asn.is_some()
-
-                && info.parent_ingress == query.parent_ingress
-                && info.remote_asn == query.remote_asn
-                && info.remote_addr == query.remote_addr
-
-                && info.rib_type == query.rib_type
-            {
+            if find_existing_for!(info, query,
+                parent_ingress, remote_addr, remote_asn,
+                rib_type, peer_type, distinguisher
+            ) {
+                    log::debug!("found existing peer, id {id}");
                     return Some((*id, info.clone()))
             }
         }
@@ -160,12 +212,10 @@ impl Register {
         let lock = self.info.read().unwrap();
         log::debug!("query: {query:?}");
         for (id, info) in lock.iter() {
-            if info.parent_ingress.is_some()
-                && info.remote_addr.is_some()
-
-                && info.parent_ingress == query.parent_ingress
-                && info.remote_addr == query.remote_addr
-            {
+            if find_existing_for!(info, query,
+                parent_ingress, remote_addr
+            ) {
+                    log::debug!("found matching bmp router, id {id}");
                     return Some((*id, info.clone()))
             }
         }
@@ -174,71 +224,41 @@ impl Register {
     }
 }
 
-/// Information pertaining to an [`IngressId`]
-///
-/// The `IngressInfo` struct is quite broad and generic in nature, featuring
-/// fields that might not make sense in all use cases. Therefore, everything
-/// is wrapped as an `Option`, giving the user (mostly connector/ingress
-/// components within Rotonda) the flexibilty to fill in what makes sense in
-/// their specific case.
-#[derive(Clone, Debug, Default)]
-#[serde_with::skip_serializing_none]
-#[derive(serde::Serialize)]
-pub struct IngressInfo {
-    pub unit_name: Option<String>,
-    // changed to IpAddr because one of the BMP/BGP connectors did not have
-    // SocketAddr for us available. Ideally we change this back to SocketAddr
-    // though. remote_addr: Option<SocketAddr>,
-    pub parent_ingress: Option<IngressId>,
-    pub remote_addr: Option<IpAddr>,
-    pub remote_asn: Option<Asn>,
-    pub rib_type: Option<RibType>,
-    pub filename: Option<PathBuf>,
-    pub name: Option<String>,
-    pub desc: Option<String>,
-    // pub last_active: Instant ? to enable 'reconnecting' remotes?
-}
-
 impl IngressInfo {
     pub fn new() -> Self {
         Self::default()
     }
-
-    pub fn with_unit_name(self, unit_name: impl Into<String>) -> Self {
-        Self { unit_name: Some(unit_name.into()), ..self }
-    }
-
-    pub fn with_parent(self, parent: IngressId) -> Self {
-        Self { parent_ingress: Some(parent), ..self }
-    }
-
-    pub fn with_remote_addr(self, addr: IpAddr) -> Self {
-        Self { remote_addr: Some(addr), ..self }
-    }
-
-    pub fn with_remote_asn(self, asn: Asn) -> Self {
-        Self { remote_asn: Some(asn), ..self }
-    }
-
-    pub fn with_rib_type(self, rib_type: RibType) -> Self {
-        Self { rib_type: Some(rib_type), ..self }
-    }
-
-    pub fn with_filename(self, path: PathBuf) -> Self {
-        Self { filename: Some(path), ..self }
-    }
-
-    pub fn with_name(self, name: impl Into<String>) -> Self {
-        Self { name: Some(name.into()), ..self }
-    }
-
-    pub fn with_desc(self, desc: impl Into<String>) -> Self {
-        Self { desc: Some(desc.into()), ..self }
-    }
 }
+
+// This constructs the [`IngressInfo`] struct, used as values in the Register.
+info_for_field!(IngressInfo{
+   unit_name: String,
+   parent_ingress: IngressId,
+   remote_addr: IpAddr,
+   remote_asn: Asn,
+   rib_type: RibType,
+   filename: PathBuf,
+   name: String,
+   desc: String,
+   local_asn: Asn,
+   peer_type: PeerType,
+   distinguisher: [u8; 8]
+});
 
 #[cfg(test)]
 mod tests {
 
+    use super::*;
 
+    #[test]
+    fn all_fields() {
+        let info = IngressInfo::new()
+            .with_local_asn(Asn::from_u32(1234));
+        assert_eq!(info.local_asn, Some(Asn::from_u32(1234)));
+    }
+
+    #[test]
+    fn non_mandatory() {
+        todo!()
+    }
 }

--- a/src/units/bmp_tcp_in/state_machine/machine.rs
+++ b/src/units/bmp_tcp_in/state_machine/machine.rs
@@ -29,6 +29,7 @@ use log::{debug, error, warn};
 use inetnum::addr::Prefix;
 use rotonda_store::prefix_record::RouteStatus;
 use routecore::bgp::fsm::session;
+use routecore::bmp::message::InformationTlvIter;
 use routecore::{
     bgp::nlri::afisafi::IsPrefix,
     bgp::nlri::afisafi::Nlri,
@@ -413,6 +414,7 @@ pub trait PeerAware {
         eor_capable: bool,
         ingress_register: Arc<ingress::Register>,
         bmp_ingress_id: ingress::IngressId,
+        tlv_iter: InformationTlvIter,
     ) -> bool;
 
     fn get_peers(&self) -> Keys<'_, PerPeerHeader<Bytes>, PeerState>;
@@ -505,12 +507,15 @@ where
             .capabilities()
             .any(|cap| cap.typ() == CapabilityType::GracefulRestart);
 
+        let tlv_iter = msg.information_tlvs();
+
         if !self.details.add_peer_config(
             pph,
             config,
             eor_capable,
             self.ingress_register.clone(),
             self.ingress_id,
+            tlv_iter,
         ) {
             // This is unexpected. How can we already have an entry in
             // the map for a peer which is currently up (i.e. we have
@@ -1216,16 +1221,26 @@ impl PeerAware for PeerStates {
         eor_capable: bool,
         ingress_register: Arc<ingress::Register>,
         bmp_ingress_id: ingress::IngressId,
+        mut tlv_iter: InformationTlvIter,
     ) -> bool {
         let mut added = false;
 
-        let query_ingress = ingress::IngressInfo::new()
+        let mut query_ingress = ingress::IngressInfo::new()
             .with_parent_ingress(bmp_ingress_id)
             .with_remote_addr(pph.address())
             .with_remote_asn(pph.asn())
             .with_rib_type(pph.rib_type())
             .with_peer_type(pph.peer_type())
-            .with_distinguisher(TryInto::<[u8; 8]>::try_into(&pph.distinguisher()[..8]).unwrap());
+            .with_distinguisher(TryInto::<[u8; 8]>::try_into(&pph.distinguisher()[..8]).unwrap())
+        ;
+
+        if let Some(vrf_name) = tlv_iter
+            .find(|t| t.typ() == InformationTlvType::VrfTableName) {
+                query_ingress = query_ingress.with_vrf_name(
+                    String::from_utf8_lossy(vrf_name.value())
+                );
+        }
+
         let peer_ingress_id;
         if let Some((ingress_id, _ingress_info)) =
             ingress_register.find_existing_peer(&query_ingress)

--- a/src/units/bmp_tcp_in/state_machine/machine.rs
+++ b/src/units/bmp_tcp_in/state_machine/machine.rs
@@ -1220,10 +1220,12 @@ impl PeerAware for PeerStates {
         let mut added = false;
 
         let query_ingress = ingress::IngressInfo::new()
-            .with_parent(bmp_ingress_id)
+            .with_parent_ingress(bmp_ingress_id)
             .with_remote_addr(pph.address())
             .with_remote_asn(pph.asn())
-            .with_rib_type(pph.rib_type());
+            .with_rib_type(pph.rib_type())
+            .with_peer_type(pph.peer_type())
+            .with_distinguisher(TryInto::<[u8; 8]>::try_into(&pph.distinguisher()[..8]).unwrap());
         let peer_ingress_id;
         if let Some((ingress_id, _ingress_info)) =
             ingress_register.find_existing_peer(&query_ingress)

--- a/src/units/bmp_tcp_in/state_machine/states/dumping.rs
+++ b/src/units/bmp_tcp_in/state_machine/states/dumping.rs
@@ -12,7 +12,7 @@ use routecore::bgp::{
     types::AfiSafiType,
 };
 use routecore::bmp::message::{
-    Message as BmpMsg, PerPeerHeader, TerminationMessage,
+    InformationTlvIter, Message as BmpMsg, PerPeerHeader, TerminationMessage
 };
 use smallvec::SmallVec;
 
@@ -380,6 +380,7 @@ impl PeerAware for Dumping {
         eor_capable: bool,
         ingress_register: Arc<ingress::Register>,
         bmp_ingress_id: ingress::IngressId,
+        tlv_iter: InformationTlvIter,
     ) -> bool {
         self.peer_states.add_peer_config(
             pph,
@@ -387,6 +388,7 @@ impl PeerAware for Dumping {
             eor_capable,
             ingress_register,
             bmp_ingress_id,
+            tlv_iter,
         )
     }
 

--- a/src/units/bmp_tcp_in/state_machine/states/updating.rs
+++ b/src/units/bmp_tcp_in/state_machine/states/updating.rs
@@ -11,7 +11,7 @@ use routecore::{
         nlri::afisafi::Nlri,
         types::AfiSafiType,
     },
-    bmp::message::{Message as BmpMsg, PerPeerHeader, TerminationMessage},
+    bmp::message::{InformationTlvIter, Message as BmpMsg, PerPeerHeader, TerminationMessage},
 };
 use smallvec::SmallVec;
 
@@ -215,6 +215,7 @@ impl PeerAware for Updating {
         eor_capable: bool,
         ingress_register: Arc<ingress::Register>,
         bmp_ingress_id: ingress::IngressId,
+        tlv_iter: InformationTlvIter,
     ) -> bool {
         self.peer_states.add_peer_config(
             pph,
@@ -222,6 +223,7 @@ impl PeerAware for Updating {
             eor_capable,
             ingress_register,
             bmp_ingress_id,
+            tlv_iter,
         )
     }
 

--- a/src/units/bmp_tcp_in/unit.rs
+++ b/src/units/bmp_tcp_in/unit.rs
@@ -440,7 +440,7 @@ impl BmpTcpInRunner {
                     ControlFlow::Continue(Ok((tcp_stream, client_addr))) => {
 
                         let query_ingress = IngressInfo::new()
-                            .with_parent(unit_ingress_id)
+                            .with_parent_ingress(unit_ingress_id)
                             .with_remote_addr(client_addr.ip())
                         ;
                         let router_ingress_id;

--- a/src/units/mrt_file_in/unit.rs
+++ b/src/units/mrt_file_in/unit.rs
@@ -221,7 +221,7 @@ impl MrtInRunner {
                 withdrawals_sent += rr_unreach.len();
 
                 let ingress_query = IngressInfo::new()
-                        .with_parent(parent_id)
+                        .with_parent_ingress(parent_id)
                         .with_remote_addr(msg.peer_addr())
                         .with_remote_asn(msg.peer_asn())
                 ;
@@ -356,7 +356,7 @@ impl MrtInRunner {
                 ingresses.update_info(
                     id,
                     IngressInfo::new()
-                        .with_parent(parent_id)
+                        .with_parent_ingress(parent_id)
                         .with_remote_addr(peer_entry.addr)
                         .with_remote_asn(peer_entry.asn)
                         .with_filename(filename.clone()),


### PR DESCRIPTION
With this PR, we now store BMP Peer type/distinguisher and VRF/Table names in the ingress register, return them in the HTTP API responses, and use them when trying to correlate ingresses.



NB: this currently requires routecore/main via git because of some small but crucial fixes.