### PR TITLE
Api improvements: compression, json serialization/streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ec5f6c2f8bc326c994cb9e241cc257ddaba9afa8555a43cffbb5dd86efaa37"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +547,23 @@ name = "compare"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7ac3e5b97fdce45e8922fb05cae2c37f7bbd63d30dd94821dacfd8f3f2bf2"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "config"
@@ -1088,9 +1118,9 @@ checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2055,6 +2085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2768,6 +2799,7 @@ dependencies = [
  "tokio",
  "tokio-metrics",
  "toml 0.8.23",
+ "tower-http",
  "url",
  "uuid",
 ]
@@ -3182,6 +3214,12 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "similar"
@@ -3607,6 +3645,26 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "async-compression",
+ "bitflags 2.9.4",
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2798,6 +2798,7 @@ dependencies = [
  "syslog",
  "tokio",
  "tokio-metrics",
+ "tokio-stream",
  "toml 0.8.23",
  "tower-http",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ futures-util       = "0.3.31"
 micromap           = "0.0.19"
 paste              = "1.0.15"
 axum               = { version = "0.8.4", features = ["query", "http1", "http2", "tokio"], default-features = false }
+tower-http         = { version = "0.5.2", features = ["compression-gzip"], optional = true }
 serde_qs           = "0.15.0"
 rshtml             = "0.2.0"
 
@@ -115,7 +116,7 @@ strip = true
 default = ["http-api-gzip"]
 
 # Enable GZIP compression of the HTTP /metrics response
-http-api-gzip = ["flate2"]
+http-api-gzip = ["flate2", "tower-http"]
 
 [build-dependencies]
 rshtml = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ rotonda-store      = { workspace = true }
 serde_with         = "3"
 smallvec           = { version = "1.11", features = ["const_generics", "const_new", "union"] }
 tokio-metrics      = { version = "0.3", default-features = false }
+tokio-stream       = "0.1.17"
 uuid               = { version = "1.4", features = ["v4", "fast-rng"] }
 sha2               = "0.10.8"
 csv                = "1.3.1"

--- a/src/http_ng.rs
+++ b/src/http_ng.rs
@@ -1,6 +1,8 @@
 use std::{net::SocketAddr, sync::{Arc, OnceLock}};
 
 use axum::routing::get;
+#[cfg(feature = "http-api-gzip")]
+use tower_http::compression::CompressionLayer;
 use log::{debug, error};
 use tokio::{sync::mpsc, task::JoinHandle};
 
@@ -146,9 +148,13 @@ impl Api {
             let (signal_tx, signal_rx) = mpsc::channel::<()>(1);
             self.signal_txs.push(signal_tx);
 
-            let app = self.router.clone().with_state(
+            let mut app = self.router.clone().with_state(
                 self.cloned_api_state()
             );
+            #[cfg(feature = "http-api-gzip")]
+            {
+                app = app.layer(CompressionLayer::new());
+            }
 
             let h = tokio::spawn(async move {
                 let listener = match tokio::net::TcpListener::bind(interface).await {
@@ -221,4 +227,3 @@ impl axum::response::IntoResponse for ApiError {
         ).into_response()
     }
 }
-

--- a/src/units/rib_unit/http_ng.rs
+++ b/src/units/rib_unit/http_ng.rs
@@ -1,6 +1,8 @@
-use std::{collections::HashMap, fmt::Display, net::{Ipv4Addr, Ipv6Addr}};
+use std::{fmt::Display, io, net::{Ipv4Addr, Ipv6Addr}};
+use std::io::Write;
 
-use axum::{extract::{Path, Query, State}, response::IntoResponse};
+use axum::{body::Body, extract::{Path, Query, State}, response::IntoResponse};
+use bytes::Bytes;
 use inetnum::{addr::Prefix, asn::Asn};
 use log::{debug, warn};
 use routecore::{bgp::{communities::{LargeCommunity, StandardCommunity}, path_attributes::PathAttributeType, types::AfiSafiType}, bmp::message::RibType};
@@ -8,8 +10,10 @@ use serde::Deserialize;
 use serde_with::serde_as;
 use serde_with::formats::CommaSeparator;
 use serde_with::StringWithSeparator;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
 
-use crate::{http_ng::{Api, ApiError, ApiState}, ingress::IngressId, roto_runtime::types::PeerRibType, units::rib_unit::rpki::RovStatus};
+use crate::{http_ng::{Api, ApiError, ApiState}, ingress::IngressId, representation::{GenOutput, Json}, roto_runtime::types::PeerRibType, units::rib_unit::rpki::RovStatus};
 
 // XXX The actual querying of the store should be similar to how we query the ingress register,
 // i.e. with the Rib unit constructing one type of responses (so a wrapper around the
@@ -146,6 +150,61 @@ pub enum Include {
     LessSpecifics,
 }
 
+const STREAM_CHUNK_SIZE: usize = 256 * 1024;
+
+struct ChannelWriter {
+    sender: mpsc::Sender<Result<Bytes, io::Error>>,
+    buffer: Vec<u8>,
+}
+
+impl ChannelWriter {
+    fn new(sender: mpsc::Sender<Result<Bytes, io::Error>>) -> Self {
+        Self {
+            sender,
+            buffer: Vec::with_capacity(STREAM_CHUNK_SIZE),
+        }
+    }
+
+    fn send_buffer(&mut self) -> io::Result<()> {
+        if self.buffer.is_empty() {
+            return Ok(());
+        }
+        let chunk = Bytes::copy_from_slice(&self.buffer);
+        self.buffer.clear();
+        let _ = self.sender.blocking_send(Ok(chunk));
+        Ok(())
+    }
+}
+
+impl io::Write for ChannelWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buffer.extend_from_slice(buf);
+        if self.buffer.len() >= STREAM_CHUNK_SIZE {
+            let _ = self.send_buffer();
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.send_buffer()
+    }
+}
+
+fn stream_search_result(
+    search_result: super::rib::SearchResult,
+) -> impl IntoResponse {
+    let (tx, rx) = mpsc::channel::<Result<Bytes, io::Error>>(64);
+    let stream = ReceiverStream::new(rx);
+
+    tokio::task::spawn_blocking(move || {
+        let mut writer = ChannelWriter::new(tx);
+        let _ = search_result.write(&mut Json(&mut writer));
+        let _ = writer.flush();
+    });
+
+    ([("content-type", "application/json")], Body::from_stream(stream))
+}
+
 #[derive(Debug)]
 pub struct UnknownInclude;
 impl Display for UnknownInclude {
@@ -184,19 +243,13 @@ async fn search_ipv4unicast(
 
     let prefix = Prefix::new_v4(prefix, prefix_len).map_err(|e| ApiError::BadRequest(e.to_string()))?;
     let s = state.store.clone();
-    let mut res = Vec::new();
-    match s.get().map(|store|
-        store.search_and_output_routes(
-            crate::representation::Json(&mut res),
-            AfiSafiType::Ipv4Unicast,
-            prefix,
-            filter
-        )
-    ) {
-        Some(Ok(())) => Ok(([("content-type", "application/json")], res)),
-        Some(Err(e)) => Err(ApiError::BadRequest(e)),
-        None => Err(ApiError::InternalServerError("store unavailable".into()))
-    }
+    let search_result = match s.get() {
+        Some(store) => store.search_routes(AfiSafiType::Ipv4Unicast, prefix, filter)
+            .map_err(ApiError::BadRequest)?,
+        None => return Err(ApiError::InternalServerError("store unavailable".into())),
+    };
+
+    Ok(stream_search_result(search_result))
 }
 
 // Search all routes, we mimic a 0.0.0.0/0 search, but most (or all) results will actually be
@@ -217,19 +270,13 @@ async fn search_ipv6unicast(
 
     let prefix = Prefix::new_v6(prefix, prefix_len).map_err(|e| ApiError::BadRequest(e.to_string()))?;
     let s = state.store.clone();
-    let mut res = Vec::new();
-    match s.get().map(|store|
-        store.search_and_output_routes(
-            crate::representation::Json(&mut res),
-            AfiSafiType::Ipv6Unicast,
-            prefix,
-            filter
-        )
-    ) {
-        Some(Ok(())) => Ok(([("content-type", "application/json")], res)),
-        Some(Err(e)) => Err(ApiError::BadRequest(e)),
-        None => Err(ApiError::InternalServerError("store unavailable".into()))
-    }
+    let search_result = match s.get() {
+        Some(store) => store.search_routes(AfiSafiType::Ipv6Unicast, prefix, filter)
+            .map_err(ApiError::BadRequest)?,
+        None => return Err(ApiError::InternalServerError("store unavailable".into())),
+    };
+
+    Ok(stream_search_result(search_result))
 }
 
 // Search all routes, we mimic a ::/0 search, but most (or all) results will actually be


### PR DESCRIPTION
When i started to test rotonda with RouteViews MRT import (quite big) and /routes endpoint i noticed that there is significant initial delay, then there is huge spike in memory consumption and last, answer is quite large (9GB+) and not compressed.

I implemented compression, which might be significant for today prices, especially at cloud (244Mb vs 9GB!), and implemented serialization, where it outputs data to client gradually, and instantly, as soon as it start to receive results from search_routes, without buffering much. I set chunk size 256KB for now, it looks like transfer speed is at least not worse (maybe better in my case due lower memory pressure).

Here is some tests results:
```
Vanilla (no compression, no streaming):

curl -D - \
    http://127.0.0.1:9090/api/v1/ribs/ipv4unicast/routes \
    -o /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:35 --:--:--     0
HTTP/1.1 200 OK
content-type: application/json
vary: accept-encoding
transfer-encoding: chunked
date: Fri, 26 Dec 2025 23:23:36 GMT

100 9766M    0 9766M    0     0   265M      0 --:--:--  0:00:36 --:--:-- 2559M

With compression:

curl -H 'Accept-Encoding: gzip' --compressed -D -     http://127.0.0.1:9090/api/v1/ribs/ipv4unicast/routes     -o /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:37 --:--:--     0
HTTP/1.1 200 OK
content-type: application/json
vary: accept-encoding
content-encoding: gzip
transfer-encoding: chunked
date: Fri, 26 Dec 2025 23:21:14 GMT

100  244M    0  244M    0     0  3298k      0 --:--:--  0:01:15 --:--:-- 6207k


With streaming without compression (disabled on client):
curl -D - \
    http://127.0.0.1:9090/api/v1/ribs/ipv4unicast/routes \
    -o /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
HTTP/1.1 200 OK
content-type: application/json
vary: accept-encoding
transfer-encoding: chunked
date: Fri, 26 Dec 2025 23:43:16 GMT

100 9766M    0 9766M    0     0   272M      0 --:--:--  0:00:35 --:--:--  290M

With streaming with compression:
curl -H 'Accept-Encoding: gzip' --compressed -D -     http://127.0.0.1:9090/api/v1/ribs/ipv4unicast/routes     -o /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0HTTP/1.1 200 OK
content-type: application/json
vary: accept-encoding
content-encoding: gzip
transfer-encoding: chunked
date: Fri, 26 Dec 2025 23:48:59 GMT

100  244M    0  244M    0     0  5722k      0 --:--:--  0:00:43 --:--:-- 5954k
```