### PR TITLE
Add support for Ubuntu Resolute

### DIFF
--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -4,10 +4,10 @@
 pkg:
   - 'rotonda'
 image:
-  - "ubuntu:bionic"   # ubuntu/18.04
   - "ubuntu:focal"    # ubuntu/20.04
   - "ubuntu:jammy"    # ubuntu/22.04
   - "ubuntu:noble"    # ubuntu/24.04
+  - "ubuntu:resolute" # ubuntu/26.04
   - "debian:buster"   # debian/10
   - "debian:bullseye" # debian/11
   - "debian:bookworm" # debian/12
@@ -87,12 +87,9 @@ test-mode:
   - 'fresh-install'
 
 
-# Disable upgrade testing on Alma Linux 10 and Debian Bookworm as we haven't published any packages for
+# Disable upgrade testing on Ubuntu Resolute Raccoon as we haven't published any packages for
 # those O/S versions yet.
-#test-exclude:
-#  - pkg: 'rotonda'
-#    image: 'almalinux:10'
-#    mode: 'upgrade-from-published'
-#  - pkg: 'rotonda'
-#    image: 'debian:trixie'
-#    mode: 'upgrade-from-published'
+test-exclude:
+ - pkg: 'rotonda'
+   image: 'ubuntu:resolute'
+   mode: 'upgrade-from-published'

--- a/pkg/rules/packages-to-test.yml
+++ b/pkg/rules/packages-to-test.yml
@@ -5,7 +5,7 @@ image:
   - "ubuntu:focal"    # ubuntu/20.04
   - "ubuntu:jammy"    # ubuntu/22.04
   - "ubuntu:noble"    # ubuntu/24.04
-  - "ubuntu:resolute" # ubuntu/24.04
+  - "ubuntu:resolute" # ubuntu/26.04
   - "debian:buster"   # debian/10
   - "debian:bullseye" # debian/11
   - "debian:bookworm" # debian/12

--- a/pkg/rules/packages-to-test.yml
+++ b/pkg/rules/packages-to-test.yml
@@ -2,16 +2,16 @@
 pkg:
   - 'rotonda'
 image:
-  - "ubuntu:bionic"   # ubuntu/18.04
   - "ubuntu:focal"    # ubuntu/20.04
   - "ubuntu:jammy"    # ubuntu/22.04
   - "ubuntu:noble"    # ubuntu/24.04
+  - "ubuntu:resolute" # ubuntu/24.04
   - "debian:buster"   # debian/10
   - "debian:bullseye" # debian/11
   - "debian:bookworm" # debian/12
   - 'almalinux:8'     # compatible with EOL centos:8
   - 'almalinux:9'
-  # no almalinux:10 due to lack of test-image
+  - 'almalinux:10'
 target:
   - 'x86_64'
 test-image:


### PR DESCRIPTION
This PR adds Ubuntu Resolute Raccoon (26.04) to the pkg workflow, and remove Ubuntu Bionic Beaver (18.04).

Successful run: https://github.com/NLnetLabs/rotonda/actions/runs/25793123361